### PR TITLE
Customizable Access Control (NetworkACL) Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The setup includes a **VPC, Security Group, and an EC2 Instance**, ensuring a se
 - ✅ **Security Group**: Controlled inbound and outbound access to allow secure SSH and development tools.
 - ✅ **Scalability**: Supports heavy workloads for software builds, testing, and development.
 - ✅ **Infrastructure as Code**: Easily deploy, modify, and manage using AWS CDK.
+- ✅ **Customizable Access Control (NetworkACL) Support**: for subnets to enhance security.
+  - Allows inbound traffic only from specified IP addresses.
+  - If no whitelist IPs are provided, all inbound traffic is allowed by default.
 
 ## **🚀 Upcoming Features**
 - ✨ **Resource Scheduling**: Start and stop the EC2 instance based on a  developer's schedule.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The setup includes a **VPC, NetworkACL, Security Group, and an EC2 Instance**, e
 - ✅ **Infrastructure as Code**: Easily deploy, modify, and manage using AWS CDK.
 - ✅ **Customizable Access Control (NetworkACL) Support**: for subnets to enhance security.
   - Allows inbound traffic only from specified IP addresses.
-  - If no whitelist IPs are provided, all inbound traffic is allowed by default.
+  - If no whitelist IPs are provided (in the `parameters.ts`), all inbound/outbound traffic is allowed by default.
 
 ## **🚀 Upcoming Features**
 - ✨ **Resource Scheduling**: Start and stop the EC2 instance based on a  developer's schedule.

--- a/app/lib/config/parameters.ts
+++ b/app/lib/config/parameters.ts
@@ -59,7 +59,7 @@ const AppParameters: Record<string, EnvironmentConfig> = {
           ],
         },
       ],
-      whitelistIps: [], // empty whitelist, no NetworkACl will be created
+      whitelistIps: [], // empty whitelist, all ips are allowed by default
     },
   },
 };

--- a/app/lib/config/parameters.ts
+++ b/app/lib/config/parameters.ts
@@ -6,6 +6,7 @@ export interface EnvironmentConfig {
   env: Environment;
   devInstanceServiceProps: {
     ec2Instances: SingleEc2InstanceProps[];
+    whitelistIps?: string[];
   };
 }
 
@@ -33,6 +34,7 @@ const AppParameters: Record<string, EnvironmentConfig> = {
           ],
         },
       ],
+      whitelistIps: [],
     },
   },
   dev: {
@@ -57,6 +59,7 @@ const AppParameters: Record<string, EnvironmentConfig> = {
           ],
         },
       ],
+      whitelistIps: [], // empty whitelist, no NetworkACl will be created
     },
   },
 };

--- a/app/lib/services/dev-instance-provider/constructs/VpcConstruct.ts
+++ b/app/lib/services/dev-instance-provider/constructs/VpcConstruct.ts
@@ -1,11 +1,15 @@
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
+import { NetworkUtils } from "utils/network-utils";
 
+interface VpcConstructProps {
+  whitelistIps?: string[];
+}
 export class VpcConstruct extends Construct {
   public readonly vpc: ec2.Vpc;
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props: VpcConstructProps) {
     super(scope, id);
 
     // ✅ Create a VPC with a Public Subnet (Ensures deletion on `cdk destroy`)
@@ -22,6 +26,54 @@ export class VpcConstruct extends Construct {
           cidrMask: 26, // 192.168.1.0 to 192.168.1.63 (64 IPs) - (59 usable IPs)
         },
       ],
+    });
+
+    // ✅ Add Network ACL to restrict access to the VPC based on the whitelist IPs
+    const publicSubnets = this.vpc.selectSubnets({
+      subnetType: ec2.SubnetType.PUBLIC,
+    }).subnets;
+
+    const networkACL = new ec2.NetworkAcl(this, "EC2CodeNetworkACL", {
+      vpc: this.vpc,
+      networkAclName: "EC2CodeNetworkACL",
+      subnetSelection: { subnets: publicSubnets },
+    });
+
+    if (props.whitelistIps && props.whitelistIps.length > 0) {
+      props.whitelistIps.forEach((ip, index) => {
+        networkACL.addEntry(`AllowSpecificIP${index}`, {
+          ruleNumber: 100 + index,
+          cidr: ec2.AclCidr.ipv4(NetworkUtils.formatToCidr(ip)),
+          traffic: ec2.AclTraffic.allTraffic(),
+          direction: ec2.TrafficDirection.INGRESS,
+          ruleAction: ec2.Action.ALLOW,
+        });
+      });
+
+      networkACL.addEntry("DenyAllInbound", {
+        ruleNumber: 200,
+        cidr: ec2.AclCidr.anyIpv4(),
+        traffic: ec2.AclTraffic.allTraffic(),
+        direction: ec2.TrafficDirection.INGRESS,
+        ruleAction: ec2.Action.DENY,
+      });
+    } else {
+      // If no whitelist IPs are provided, allow all inbound traffic
+      networkACL.addEntry("AllowAllInbound", {
+        ruleNumber: 100,
+        cidr: ec2.AclCidr.anyIpv4(),
+        traffic: ec2.AclTraffic.allTraffic(),
+        direction: ec2.TrafficDirection.INGRESS,
+        ruleAction: ec2.Action.ALLOW,
+      });
+    }
+
+    networkACL.addEntry("AllowAllOutbound", {
+      ruleNumber: 100,
+      cidr: ec2.AclCidr.anyIpv4(),
+      traffic: ec2.AclTraffic.allTraffic(),
+      direction: ec2.TrafficDirection.EGRESS,
+      ruleAction: ec2.Action.ALLOW,
     });
 
     // ✅ Ensure deletion on `cdk destroy`

--- a/app/lib/services/dev-instance-provider/stack/dev-instance-network-stack.ts
+++ b/app/lib/services/dev-instance-provider/stack/dev-instance-network-stack.ts
@@ -2,15 +2,22 @@ import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { VpcConstruct } from "dev-instance-provider/constructs/VpcConstruct";
+import { DevInstanceNetworkStackProps } from "lib/types";
 
 export class DevInstanceNetworkStack extends cdk.Stack {
   public readonly vpc: ec2.Vpc;
 
-  constructor(scope: Construct, id: string, props: cdk.StackProps) {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: DevInstanceNetworkStackProps
+  ) {
     super(scope, id, props);
 
     // ✅ Deploy VPC
-    const vpcStack = new VpcConstruct(this, "VpcStack");
+    const vpcStack = new VpcConstruct(this, "VpcStack", {
+      whitelistIps: props.whitelistIps,
+    });
 
     this.vpc = vpcStack.vpc;
   }

--- a/app/lib/services/dev-instance-provider/stack/dev-instance-stage.ts
+++ b/app/lib/services/dev-instance-provider/stack/dev-instance-stage.ts
@@ -15,6 +15,7 @@ export class DevInstanceStage extends cdk.Stage {
         // Added env here because If envParameters.env contains a different AWS account or region than DevInstanceNetworkStack,
         // CDK will not allow cross-stack references.
         env: props.env,
+        whitelistIps: props.whitelistIps,
       }
     );
 

--- a/app/lib/types/index.ts
+++ b/app/lib/types/index.ts
@@ -1,6 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Environment } from "aws-cdk-lib";
+import { EnvironmentConfig } from "config/parameters";
 
 export interface Ec2KeyPairConstructProps {
   keyPairName: string; // Key Pair Name passed as a property
@@ -35,6 +36,11 @@ export interface DevInstanceEc2StackProps extends cdk.StackProps {
   ec2Instances: SingleEc2InstanceProps[];
 }
 
-export interface DevInstanceStageProps extends cdk.StageProps {
-  ec2Instances: SingleEc2InstanceProps[];
+export interface DevInstanceNetworkStackProps extends cdk.StackProps {
+  whitelistIps?: string[];
 }
+
+type DevInstanceServiceProps = EnvironmentConfig["devInstanceServiceProps"];
+export interface DevInstanceStageProps
+  extends cdk.StageProps,
+    DevInstanceServiceProps {}


### PR DESCRIPTION
✅ **Customizable Access Control (NetworkACL) Support**: for subnets to enhance security.
  - Allows inbound traffic only from specified IP addresses.
  - If no whitelist IPs are provided (in the `parameters.ts`), all inbound/outbound traffic is allowed by default.